### PR TITLE
EDEX-116 tag local images to avoid clobbering

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -82,10 +82,13 @@ node(buildNode) {
             error "Tests failed. Not updating image"
         }
 
+        gitsha = ceBuild.getGitsha() // may be used to validate /info endpoints
+        echo "DEBUG: gitsha: $gitsha"
+
         stage "publish"
         sh 'docker images'
-        sh "docker tag edex/directory-server ccctechcenter/cccnext-directory-server:${IMAGE_TAG}"
-        sh "docker tag edex/network-server ccctechcenter/cccnext-network-server:${IMAGE_TAG}"
+        sh "docker tag edex/directory-server:${gitsha} ccctechcenter/cccnext-directory-server:${IMAGE_TAG}"
+        sh "docker tag edex/network-server:${gitsha} ccctechcenter/cccnext-network-server:${IMAGE_TAG}"
 
         withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'ccctech-dockerhub-public-id', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD']]) {
             try { 

--- a/directoryServer/pom.xml
+++ b/directoryServer/pom.xml
@@ -316,6 +316,10 @@
 
                 <configuration>
                     <imageName>${docker.image.prefix}/${project.artifactId}</imageName>
+                    <imageTags>
+                        <imageTag>latest</imageTag>
+                        <imageTag>${git.commit.id.abbrev}</imageTag>
+                    </imageTags>
                     <dockerDirectory>${basedir}/src/main/docker</dockerDirectory>
                     <resources>
                         <resource>

--- a/networkServer/pom.xml
+++ b/networkServer/pom.xml
@@ -257,6 +257,10 @@
 
 				<configuration>
 					<imageName>${docker.image.prefix}/${project.artifactId}</imageName>
+                    <imageTags>
+                        <imageTag>latest</imageTag>
+                        <imageTag>${git.commit.id.abbrev}</imageTag>
+                    </imageTags>
 					<dockerDirectory>${basedir}/src/main/docker</dockerDirectory>
 					<resources>
 						<resource>


### PR DESCRIPTION
Using gitsha to insure no clobbering occurs when building on the build boxes. Reference https://github.com/spotify/docker-maven-plugin