### PR TITLE
DEVOPS-318 Update docker base image to openjdk:8

### DIFF
--- a/directoryServer/src/main/docker/Dockerfile
+++ b/directoryServer/src/main/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8
+FROM openjdk:8
 
 # add the virtual directory from the host
 RUN mkdir /opt/edexchange

--- a/networkServer/src/main/docker/Dockerfile
+++ b/networkServer/src/main/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8
+FROM openjdk:8
 
 RUN mkdir /opt/edexchange
 


### PR DESCRIPTION
java:8 image is deprecated. openjdk:8 is simply a new name for the
container, and is not expected to introduce any new issues to our
services.